### PR TITLE
Fix #4: Check if Github's response contains an error

### DIFF
--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -93,6 +93,18 @@ class Github extends AbstractProvider
                 $response
             );
         }
+
+        // Github returns a 200 HTTP code status for some OAuth errors. So we must inspect the data to find out if there
+        // is any errors. The company is aware of this issue and may fix it in the future, so this code below should be
+        // temporary.
+        // See: https://github.com/thephpleague/oauth2-github/issues/4
+        else if (isset($data['error'])) {
+            throw new IdentityProviderException(
+                $data['error_description'],
+                $response->getStatusCode(),
+                $response
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Btw, just noticed you try to get a string [from the `message` property](https://github.com/thephpleague/oauth2-github/blob/master/src/Provider/Github.php#L91), bug Github describes [an `error_description` property](https://developer.github.com/v3/oauth/#common-errors-for-the-access-token-request). Should I fix this? Because of this, I didn't write any tests for my use case since it would have been messy managing the `message` and `error_description` properties [in the same test](https://github.com/thephpleague/oauth2-github/blob/master/test/src/Provider/GithubTest.php#L181-L197).
