### PR TITLE
Update README to start a new session

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ $provider = new League\OAuth2\Client\Provider\Github([
     'redirectUri'       => 'https://example.com/callback-url',
 ]);
 
+// Start a new session if needed
+if ( ! session_id() ) @ session_start();
+
 if (!isset($_GET['code'])) {
 
     // If we don't have an authorization code then get one


### PR DESCRIPTION
The sample in the README fails because there's no session available and the state is never saved. 

Initializing a session fixes this and turns the snippet into a working sample.