### PR TITLE
Add a workaround retrieving the resource owner email

### DIFF
--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -89,7 +89,9 @@ class Github extends AbstractProvider
      */
     protected function getDefaultScopes()
     {
-        return [];
+        return [
+            'user.email',
+        ];
     }
 
     /**

--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -62,6 +62,29 @@ class Github extends AbstractProvider
         return $this->domain . '/api/v3/user';
     }
 
+    protected function fetchResourceOwnerDetails(AccessToken $token)
+    {
+        $response = parent::fetchResourceOwnerDetails($token);
+
+        if (($response['email'] ?? null) == null) {
+            $url = $this->getResourceOwnerDetailsUrl($token) . '/emails';
+
+            $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);
+
+            $responseEmail = $this->getParsedResponse($request);
+
+            if (false === is_array($responseEmail)) {
+                throw new \UnexpectedValueException(
+                    'Invalid response received from Authorization Server. Expected JSON.'
+                );
+            }
+
+            $response['email'] = $responseEmail[0]['email'];
+        }
+
+        return $response;
+    }
+
     /**
      * Get the default scopes used by this provider.
      *

--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -73,13 +73,7 @@ class Github extends AbstractProvider
 
             $responseEmail = $this->getParsedResponse($request);
 
-            if (! is_array($responseEmail)) {
-                throw new \UnexpectedValueException(
-                    'Invalid response received from Authorization Server. Expected JSON.'
-                );
-            }
-
-            $response['email'] = $responseEmail[0]['email'];
+            $response['email'] = $responseEmail[0]['email'] ?? null;
         }
 
         return $response;

--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -73,7 +73,7 @@ class Github extends AbstractProvider
 
             $responseEmail = $this->getParsedResponse($request);
 
-            if (false === is_array($responseEmail)) {
+            if (! is_array($responseEmail)) {
                 throw new \UnexpectedValueException(
                     'Invalid response received from Authorization Server. Expected JSON.'
                 );

--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -66,7 +66,7 @@ class Github extends AbstractProvider
     {
         $response = parent::fetchResourceOwnerDetails($token);
 
-        if (($response['email'] ?? null) == null) {
+        if (! ($response['email'] ?? null)) {
             $url = $this->getResourceOwnerDetailsUrl($token) . '/emails';
 
             $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);

--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -66,14 +66,14 @@ class Github extends AbstractProvider
     {
         $response = parent::fetchResourceOwnerDetails($token);
 
-        if (! ($response['email'] ?? null)) {
+        if (empty($response['email'])) {
             $url = $this->getResourceOwnerDetailsUrl($token) . '/emails';
 
             $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);
 
             $responseEmail = $this->getParsedResponse($request);
 
-            $response['email'] = $responseEmail[0]['email'] ?? null;
+            $response['email'] = isset($responseEmail[0]['email']) ? $responseEmail[0]['email'] : null;
         }
 
         return $response;


### PR DESCRIPTION
The resource owner email is always `null`, as stated in the issue https://github.com/thephpleague/oauth2-github/issues/19.