### PR TITLE
Allow using the `read:user` which doesnt have emails available to it

### DIFF
--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -25,6 +25,8 @@ class Github extends AbstractProvider
      */
     public $apiDomain = 'https://api.github.com';
 
+    public bool $alwaysCheckEmails = true;
+
     /**
      * Get authorization url to begin OAuth flow
      *
@@ -66,7 +68,7 @@ class Github extends AbstractProvider
     {
         $response = parent::fetchResourceOwnerDetails($token);
 
-        if (empty($response['email'])) {
+        if ($this->alwaysCheckEmails && empty($response['email'])) {
             $url = $this->getResourceOwnerDetailsUrl($token) . '/emails';
 
             $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);


### PR DESCRIPTION
Fixes thephpleague/oauth2-github/issues/24

This is just one way of doing it I suppose. Needs some thoughts on maintainers of thephpleague/oauth2-github

Allows devs to opt out of collecting emails by setting an option.

We could alternatively detect the scopes against a whitelist, automate it without an option.

