### PR TITLE
Bugfix: Typo in scope 'user:email' instead of 'user.email', fixes #24

### DIFF
--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -90,7 +90,7 @@ class Github extends AbstractProvider
     protected function getDefaultScopes()
     {
         return [
-            'user.email',
+            'user:email',
         ];
     }
 


### PR DESCRIPTION
In issue #24, an error was reported if the accessed Github profile does not have a public email address. In this case, [oauth2-github](https://github.com/thephpleague/oauth2-github) tries to retrieve the email address with a call to the Github API [~/emails](https://github.com/thephpleague/oauth2-github/blob/main/src/Provider/Github.php#L70). However, this API call fails with a 404 error.

During debugging, I recognized that the root cause for this issue is a **typo** on the default scope:
- [Github.php, line 93](https://github.com/thephpleague/oauth2-github/blob/main/src/Provider/Github.php#L93)
- 'user:email' instead of 'user.email'

The attached pull request fixes this issue.

